### PR TITLE
Update 2017-11-20-near-cloud-crdt-kuhiro.md

### DIFF
--- a/posts/2017-11-20-near-cloud-crdt-kuhiro.md
+++ b/posts/2017-11-20-near-cloud-crdt-kuhiro.md
@@ -8,7 +8,7 @@ authors:
   - AndreaPasswater
 ---
 
-[Kuhirō](www.kuhiro.com) founder Russell Sullivan came to chat with us about the latest hot topic in serverless—[CRDTs](https://serverless.com/blog/crdt-explained-supercharge-serverless-at-edge/).
+[Kuhirō](http://www.kuhiro.com) founder Russell Sullivan came to chat with us about the latest hot topic in serverless—[CRDTs](https://serverless.com/blog/crdt-explained-supercharge-serverless-at-edge/).
 
 CRDTs got several mentions at ServerlessConf 2017 in NYC, but not many people fully understand what they do, or what their potential is. (...yet.)
 


### PR DESCRIPTION
The external link of www.kuhiro.com was linking to: https://serverless.com/blog/near-cloud-crdt-kuhiro/www.kuhiro.com instead of http://kuhiro.com