### PR TITLE
Specify the allowed origins properly

### DIFF
--- a/posts/2018-01-16-cors-api-gateway-survival-guide.md
+++ b/posts/2018-01-16-cors-api-gateway-survival-guide.md
@@ -194,7 +194,8 @@ functions:
           path: product/{id}
           method: get
           cors:
-            origin: '*' # <-- Specify allowed origin
+            origins:
+              - '*' # <-- Specify allowed origin
             headers: # <-- Specify allowed headers
               - Content-Type
               - X-Amz-Date


### PR DESCRIPTION
Specifying the allowed origin as `origin: '*'` does not work (results in an empty string being set for the allowed origins in API Gateway). It seems that they need to be specified as a list.