### PR TITLE
Fix handler path in fixed serverless.yml file

### DIFF
--- a/posts/2018-01-18-framework-example-golang-lambda-support.md
+++ b/posts/2018-01-18-framework-example-golang-lambda-support.md
@@ -111,7 +111,7 @@ package:
 
 functions:
   hello:
-    handler: bin/main
+    handler: bin/hello
     events:
       - http:
           path: hello


### PR DESCRIPTION
Instead of:
```
functions:
  hello:
    handler: bin/main
    events:
      - http:
          path: hello
          method: post
```
Should be:
```
functions:
  hello:
    handler: bin/hello
   ...
```
Otherwise it doesn't work, because hello example is compiled to **bin/hello** file, not to bin/main.

Makefile:
```
env GOOS=linux go build -ldflags="-s -w" -o bin/hello hello/main.go
```