### PR TITLE
Fix a minor typo in an example

### DIFF
--- a/posts/2017-08-04-serverless-python-packaging.md
+++ b/posts/2017-08-04-serverless-python-packaging.md
@@ -150,7 +150,7 @@ Is this ok? (yes) yes
 To configure our `serverless.yml` file to use the plugin, we'll add the following lines in our `serverless.yml`:
 
 ```yml
-# sererless.yml
+# serverless.yml
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
`sererless.yml` should be `serverless.yml`