### PR TITLE
fixes running serverless-express-rest-api locally with dynamodb

### DIFF
--- a/posts/2017-10-04-serverless-express-rest-api.md
+++ b/posts/2017-10-04-serverless-express-rest-api.md
@@ -462,7 +462,7 @@ Now, our DocumentClient constructor is configured to use DynamoDB local if we're
 Let's see it if works. Start up your offline server again:
 
 ```bash
-$ sls offline start
+$ sls offline start --migrate
 Dynamodb Local Started, Visit: http://localhost:8000/shell
 Serverless: DynamoDB - created table users-table-dev
 Serverless: Starting Offline: dev/us-east-1.


### PR DESCRIPTION
need to run "sls offline start" with the --migrate flag so that the tables are initialized. Otherwise I get a "Cannot do operations on a non-existent table" error.