### PR TITLE
Fixed missing `install` command from blog post steps

### DIFF
--- a/posts/2018-02-14-running-scalable-reliable-graphql-endpoint-with-serverless.md
+++ b/posts/2018-02-14-running-scalable-reliable-graphql-endpoint-with-serverless.md
@@ -104,7 +104,7 @@ Some of the main components of building your endpoint are (with links to [server
 
 ### Step 1: Configure the Serverless template
 
-We'll be using the [Serverless Framework](https://serverless.com/framework/) to build and deploy your API resources quickly. If you don't have the Framework installed, get it with `npm serverless -g`.
+We'll be using the [Serverless Framework](https://serverless.com/framework/) to build and deploy your API resources quickly. If you don't have the Framework installed, get it with `npm install serverless -g`.
 
 To start, specify in your `serverless.yml` that you are setting up a GraphQL HTTP endpoint:
 


### PR DESCRIPTION
The command to run was missing the `install` in step one