### PR TITLE
tweak how code & shell examples render in layers post

### DIFF
--- a/posts/2018-11-29-publish-aws-lambda-layers-serverless-framework.md
+++ b/posts/2018-11-29-publish-aws-lambda-layers-serverless-framework.md
@@ -53,7 +53,7 @@ layers:
 
 Run the following commands to download the contents of your layer:
 
-```bash
+```
 mkdir layer
 cd layer
 curl -O https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz
@@ -96,7 +96,7 @@ layers:
 
 Next, we’ll add a `custom` section to `serverless.yml` to specify the S3 bucket name (choose your own unique bucket name):
 
-```
+```yaml
 custom:
   bucket: MyGifMakerBucket
 ```


### PR DESCRIPTION
specifically, everythign in a shell is red without line numbers. everything in a file has linenumbers