### PR TITLE
Update 2017-10-04-serverless-express-rest-api.md to fix route/stage issue

### DIFF
--- a/posts/2017-10-04-serverless-express-rest-api.md
+++ b/posts/2017-10-04-serverless-express-rest-api.md
@@ -56,7 +56,7 @@ const serverless = require('serverless-http');
 const express = require('express')
 const app = express()
 
-app.get('/', function (req, res) {
+app.get('/dev', function (req, res) {
   res.send('Hello World!')
 })
 
@@ -76,7 +76,7 @@ service: my-express-application
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
   stage: dev
   region: us-east-1
 


### PR DESCRIPTION
First part of tutorial fails to produce a usable endpoint, because the 'dev' stage is expected as part of the Express route as '/dev'.  This is a known issue with serverless-http https://github.com/dougmoscrop/serverless-http/issues/68.