### PR TITLE
Update Python example code

### DIFF
--- a/posts/2019-11-21-debugging-with-tags.md
+++ b/posts/2019-11-21-debugging-with-tags.md
@@ -58,7 +58,7 @@ module.exports.hello = async event, context => {
 If you’re using Python, add this:
 ```javascript
 def hello(event, context):
-   context.serverless_sdk.tag_event('python-transaction', 'true', {'foo': 'bar'})
+   context.serverless_sdk.tag_event('customerId', 5, { 'newCustomer': True, 'isDemo': True})
    body = {
        "message": "Go Serverless v1.0! Your function executed successfully!",
        "input": event


### PR DESCRIPTION
In the previous version the Python example would generate something like this:

<img width="707" alt="Screen Shot 2019-12-18 at 9 24 31 AM" src="https://user-images.githubusercontent.com/6182464/71110071-6b1d5580-217b-11ea-8c18-ffe34b8f1e8f.png">

Which was confusing imo. 

I've updated it to actually allow to search by user id.