### PR TITLE
fix: Correct invalid example for websockets custom route

### DIFF
--- a/posts/2019-02-20-framework-release-v138-websockets.md
+++ b/posts/2019-02-20-framework-release-v138-websockets.md
@@ -54,7 +54,7 @@ functions:
     handler: handler.echo
     events:
       - websocket:
-          route: $echo
+          route: echo
 
 ```
 


### PR DESCRIPTION
Fix invalid example of custom websockets route, reported here: https://github.com/serverless/serverless/issues/9530